### PR TITLE
Fix DiscordRPC

### DIFF
--- a/io.github.vinegarhq.Vinegar.yml
+++ b/io.github.vinegarhq.Vinegar.yml
@@ -28,7 +28,6 @@ finish-args:
   - --env=EDITOR=nano
   - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/MangoHud/bin/:/usr/bin:/usr/lib/extensions/vulkan/OBSVkCapture/bin/:/usr/lib/extensions/vulkan/gamescope/bin/
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
-  - --filesystem=xdg-run/app/com.discordapp.Discord/discord-ipc-0
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
@@ -99,7 +98,7 @@ modules:
       - install -Dm644 ld.so.conf -t /app/etc/
       - |
         for i in {0..9}; do
-          test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$1;
+          test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
         done  
     sources:
       - type: file


### PR DESCRIPTION
Clo(ses) #57 (Dont want to close it, as I dont own a Steam Deck to test it on)

Has been an issue since implementation between Discord and Vinegar, when both are flatpaks. This should fix it

Used [This](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)#flatpak-applications) as the requirements, and upon realization that you already attempted to add it, fixed it to contain exactly what the docs said.