### PR TITLE
Fix DiscordRPC (Second attempt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ build:
 	flatpak install -y org.freedesktop.Sdk//23.08 org.freedesktop.Platform//23.08 org.freedesktop.Sdk.Extension.golang/x86_64/23.08 org.freedesktop.Sdk.Compat.i386/x86_64/23.08 org.freedesktop.Sdk.Extension.toolchain-i386/x86_64/23.08 org.freedesktop.Sdk.Extension.mingw-w64/x86_64/23.08
 	flatpak-builder --ccache --force-clean build-dir io.github.vinegarhq.Vinegar.yml
 	flatpak-builder --force-clean --user --install build-dir io.github.vinegarhq.Vinegar.yml
+	$(MAKE) post-build
+post-build:
+	sed -i '5 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.app.desktop
+	sed -i '4 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.desktop
+	sed -i '6 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.player.desktop
 run:
 	flatpak run io.github.vinegarhq.Vinegar
 clean:

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@ build:
 	flatpak install -y org.freedesktop.Sdk//23.08 org.freedesktop.Platform//23.08 org.freedesktop.Sdk.Extension.golang/x86_64/23.08 org.freedesktop.Sdk.Compat.i386/x86_64/23.08 org.freedesktop.Sdk.Extension.toolchain-i386/x86_64/23.08 org.freedesktop.Sdk.Extension.mingw-w64/x86_64/23.08
 	flatpak-builder --ccache --force-clean build-dir io.github.vinegarhq.Vinegar.yml
 	flatpak-builder --force-clean --user --install build-dir io.github.vinegarhq.Vinegar.yml
-	$(MAKE) post-build
-post-build:
-	sed -i '5 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.app.desktop
-	sed -i '4 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.desktop
-	sed -i '6 s/vinegar/discordrpc-wrapper.sh/' ~/.local/share/flatpak/app/io.github.vinegarhq.Vinegar/current/active/export/share/applications/io.github.vinegarhq.Vinegar.player.desktop
 run:
 	flatpak run io.github.vinegarhq.Vinegar
 clean:

--- a/io.github.vinegarhq.Vinegar.yml
+++ b/io.github.vinegarhq.Vinegar.yml
@@ -11,7 +11,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
   - org.freedesktop.Sdk.Extension.mingw-w64
-command: /app/bin/discordrpc-wrapper.sh
+command: /app/bin/vinegar
 
 finish-args:
   - --share=network
@@ -109,6 +109,8 @@ modules:
       - install -Dm644 catglass.svg /app/share/icons/hicolor/scalable/apps/io.github.vinegarhq.Vinegar.svg
       - install -Dm644 io.github.vinegarhq.Vinegar.png /app/share/icons/hicolor/128x128/apps/io.github.vinegarhq.Vinegar.png
       - install -Dm755 discordrpc-wrapper.sh -t /app/bin
+      - mv /app/bin/vinegar /app/bin/vinegar-binary
+      - mv /app/bin/discordrpc-wrapper.sh /app/bin/vinegar
     sources:
       - type: archive
         url: https://github.com/vinegarhq/vinegar/releases/download/v1.5.7/vinegar-v1.5.7.tar.xz

--- a/io.github.vinegarhq.Vinegar.yml
+++ b/io.github.vinegarhq.Vinegar.yml
@@ -11,7 +11,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
   - org.freedesktop.Sdk.Extension.mingw-w64
-command: /app/share/patches/discordrpc-wrapper.sh
+command: /app/bin/discordrpc-wrapper.sh
 
 finish-args:
   - --share=network
@@ -108,7 +108,7 @@ modules:
       - install -Dm644 io.github.vinegarhq.Vinegar.metainfo.xml -t /app/share/metainfo
       - install -Dm644 catglass.svg /app/share/icons/hicolor/scalable/apps/io.github.vinegarhq.Vinegar.svg
       - install -Dm644 io.github.vinegarhq.Vinegar.png /app/share/icons/hicolor/128x128/apps/io.github.vinegarhq.Vinegar.png
-      - install -Dm755 discordrpc-wrapper.sh -t /app/share/patches
+      - install -Dm755 discordrpc-wrapper.sh -t /app/bin
     sources:
       - type: archive
         url: https://github.com/vinegarhq/vinegar/releases/download/v1.5.7/vinegar-v1.5.7.tar.xz

--- a/io.github.vinegarhq.Vinegar.yml
+++ b/io.github.vinegarhq.Vinegar.yml
@@ -11,7 +11,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Compat.i386
   - org.freedesktop.Sdk.Extension.toolchain-i386
   - org.freedesktop.Sdk.Extension.mingw-w64
-command: vinegar
+command: /app/share/patches/discordrpc-wrapper.sh
 
 finish-args:
   - --share=network
@@ -112,6 +112,7 @@ modules:
       - install -Dm644 io.github.vinegarhq.Vinegar.metainfo.xml -t /app/share/metainfo
       - install -Dm644 catglass.svg /app/share/icons/hicolor/scalable/apps/io.github.vinegarhq.Vinegar.svg
       - install -Dm644 io.github.vinegarhq.Vinegar.png /app/share/icons/hicolor/128x128/apps/io.github.vinegarhq.Vinegar.png
+      - install -Dm755 discordrpc-wrapper.sh -t /app/share/patches
     sources:
       - type: archive
         url: https://github.com/vinegarhq/vinegar/releases/download/v1.5.6/vinegar-v1.5.6.tar.xz
@@ -129,6 +130,8 @@ modules:
         path: io.github.vinegarhq.Vinegar.png
       - type: file
         path: patches/io.github.vinegarhq.Vinegar.desktop
+      - type: file
+        path: patches/discordrpc-wrapper.sh
   - name: gamemode
     buildsystem: meson
     config-opts:

--- a/io.github.vinegarhq.Vinegar.yml
+++ b/io.github.vinegarhq.Vinegar.yml
@@ -96,10 +96,6 @@ modules:
       - mkdir -p /app/lib32
       - mkdir -p /app/lib/i386-linux-gnu
       - install -Dm644 ld.so.conf -t /app/etc/
-      - |
-        for i in {0..9}; do
-          test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
-        done  
     sources:
       - type: file
         path: ld.so.conf

--- a/patches/discordrpc-wrapper.sh
+++ b/patches/discordrpc-wrapper.sh
@@ -4,4 +4,4 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-vinegar "$@"
+vinegar-binary "$@"

--- a/patches/discordrpc-wrapper.sh
+++ b/patches/discordrpc-wrapper.sh
@@ -4,4 +4,4 @@ for i in {0..9}; do
     test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
 done
 
-vinegar-binary "$@"
+exec '/app/bin/vinegar-binary' "$@"

--- a/patches/discordrpc-wrapper.sh
+++ b/patches/discordrpc-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for i in {0..9}; do
+    test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+done
+
+vinegar "$@"


### PR DESCRIPTION
Fixes #57 (And this time, hopefully for real)

This is what will make sure the script I am about to upload gets placed in the sandbox properly, I used the patches folder because it made sense to me and all "install" commands in that section targeted some folder in /app/share.

It will run the loop to create the 10 ipc files from [Here](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)#flatpak-applications) now every time the vinegar command is ran, no matter what arguments are being used.

(I also cant think of another or better way of implementing this than that)